### PR TITLE
Setup branch protection for set/main

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -46,10 +46,9 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          requires_pull_request: true,
-          allows_deletions: false,
-          allows_force_pushes: false,
-          push_restrictions: [ '@eclipse-set-bot' ]
+          restricts_pushes: true
+          push_restrictions: [ '@eclipse-set-bot' ],
+          required_approving_review_count: null,
         }
       ]
     },

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -44,6 +44,15 @@ orgs.newOrg('eclipse-set') {
       delete_branch_on_merge: true,
       has_wiki: false,
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        {
+          pattern: 'main',
+          requires_pull_request: true,
+          allows_deletions: false,
+          allows_force_pushes: false,
+          push_restrictions: [ '@eclipse-set-bot' ]
+        }
+      ]
     },
     orgs.newRepo('toolboxmodel') {
       allow_merge_commit: false,

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -1,5 +1,9 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
-
+local branch_protection_rule = orgs.newBranchProtectionRule('main') {
+                                restricts_pushes: true,
+                                push_restrictions: [ '@eclipse-set-bot' ],
+                                required_approving_review_count: 0,
+                              };
 orgs.newOrg('eclipse-set') {
   settings+: {
     default_repository_permission: "none",
@@ -21,6 +25,9 @@ orgs.newOrg('eclipse-set') {
       has_issues: false,
       has_wiki: false,
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        branch_protection_rule,
+      ],
     },
     orgs.newRepo('build') {
       allow_merge_commit: false,
@@ -29,6 +36,9 @@ orgs.newOrg('eclipse-set') {
       has_issues: false,
       has_wiki: false,
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        branch_protection_rule,
+      ],      
     },
     orgs.newRepo('model') {
       allow_merge_commit: false,
@@ -37,6 +47,9 @@ orgs.newOrg('eclipse-set') {
       has_issues: false,
       has_wiki: false,
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        branch_protection_rule,
+      ],
     },
     orgs.newRepo('set') {
       allow_merge_commit: false,
@@ -45,11 +58,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          restricts_pushes: true,
-          push_restrictions: [ '@eclipse-set-bot' ],
-          required_approving_review_count: 0,
-        }
+        branch_protection_rule,
       ]
     },
     orgs.newRepo('toolboxmodel') {
@@ -59,6 +68,9 @@ orgs.newOrg('eclipse-set') {
       has_issues: false,
       has_wiki: false,
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        branch_protection_rule,
+      ],      
     },
   ],
 }

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -46,7 +46,7 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          restricts_pushes: true
+          restricts_pushes: true,
           push_restrictions: [ '@eclipse-set-bot' ],
           required_approving_review_count: null,
         }

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -45,8 +45,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        {
-          pattern: 'main',
+        orgs.newBranchProtectionRule('main') {
           requires_pull_request: true,
           allows_deletions: false,
           allows_force_pushes: false,

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -1,5 +1,5 @@
 local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
-local branch_protection_rule = orgs.newBranchProtectionRule('main') {
+local custom_branch_protection_rule(pattern) = orgs.newBranchProtectionRule(pattern) {
                                 restricts_pushes: true,
                                 push_restrictions: [ '@eclipse-set-bot' ],
                                 required_approving_review_count: 0,
@@ -26,7 +26,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        branch_protection_rule,
+        custom_branch_protection_rule(main),
       ],
     },
     orgs.newRepo('build') {
@@ -37,7 +37,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        branch_protection_rule,
+        custom_branch_protection_rule(main),
       ],      
     },
     orgs.newRepo('model') {
@@ -48,7 +48,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        branch_protection_rule,
+        custom_branch_protection_rule(main),
       ],
     },
     orgs.newRepo('set') {
@@ -58,7 +58,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        branch_protection_rule,
+        custom_branch_protection_rule(main),
       ]
     },
     orgs.newRepo('toolboxmodel') {
@@ -69,7 +69,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        branch_protection_rule,
+        custom_branch_protection_rule(main),
       ],      
     },
   ],

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -48,7 +48,7 @@ orgs.newOrg('eclipse-set') {
         orgs.newBranchProtectionRule('main') {
           restricts_pushes: true,
           push_restrictions: [ '@eclipse-set-bot' ],
-          required_approving_review_count: null,
+          required_approving_review_count: 0,
         }
       ]
     },

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -26,7 +26,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        custom_branch_protection_rule(main),
+        custom_branch_protection_rule('main'),
       ],
     },
     orgs.newRepo('build') {
@@ -37,7 +37,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        custom_branch_protection_rule(main),
+        custom_branch_protection_rule('main'),
       ],      
     },
     orgs.newRepo('model') {
@@ -48,7 +48,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        custom_branch_protection_rule(main),
+        custom_branch_protection_rule('main'),
       ],
     },
     orgs.newRepo('set') {
@@ -58,7 +58,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        custom_branch_protection_rule(main),
+        custom_branch_protection_rule('main'),
       ]
     },
     orgs.newRepo('toolboxmodel') {
@@ -69,7 +69,7 @@ orgs.newOrg('eclipse-set') {
       has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
-        custom_branch_protection_rule(main),
+        custom_branch_protection_rule('main'),
       ],      
     },
   ],


### PR DESCRIPTION
This PR setup branch protection for main branch of all eclipse-set repo:
- Allow only commit over PR (except eclipse-set-bot)
- Disable force push
- Don't allow delete branch