### PR TITLE
eclipse-set-bot bypass pull request

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -2,7 +2,6 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 local custom_branch_protection_rule(pattern) = 
   orgs.newBranchProtectionRule(pattern) {
-    bypass_pull_request_allowances: [ '@eclipse-set-bot' ],
     required_approving_review_count: 0,
   };
 

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -2,8 +2,7 @@ local orgs = import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet';
 
 local custom_branch_protection_rule(pattern) = 
   orgs.newBranchProtectionRule(pattern) {
-    restricts_pushes: true,
-    push_restrictions: [ '@eclipse-set-bot' ],
+    bypass_pull_request_allowances: [ '@eclipse-set-bot' ],
     required_approving_review_count: 0,
   };
 


### PR DESCRIPTION
By [PR#2](https://github.com/eclipse-set/.eclipsefdn/pull/2) I had set _restricts_pushes_ to "@eclipse-set-bot", because I think with this parameter, the bot can direct push to Branch without a pull request. But probably this isn't correct. This parameter allows only users in _push_restrictions_ on branch push, which I do not want.

I think the right is _bypass_pull_request_allowances_.