### PR TITLE
Add Eclipse Gitlab API token

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -18,6 +18,11 @@ orgs.newOrg('eclipse-set') {
     readers_can_create_discussions: true,
     web_commit_signoff_required: false,
   },
+  secrets+: [
+    orgs.newOrgSecret('GITLAB_API_TOKEN') {
+      value: "pass:bots/technology.set/gitlab.eclipse.org/api-token",
+    },
+  ],
   _repositories+:: [
     orgs.newRepo('browser') {
       allow_merge_commit: false,


### PR DESCRIPTION
This adds our Eclipse Gitlab API token as an organization secret for automating License review requests via Eclipse Dash/IPLab.

The token itself should already exist (since we've been using that from our JIPP instance) and according to the JIPP config/tooling [1] and [2] the path should be correct, but as I cannot verify that, please check before merging/applying. 

[1]: https://github.com/eclipse-cbi/jiro/blob/fb61fb5ab7334a6259b0c022a1bfa0b0be7b396a/jenkins-create-credentials-token.sh#L280
[2]: https://github.com/eclipse-cbi/jiro/tree/master/instances/technology.set/jenkins#L4