### PR TITLE
Add Github Bot credentials

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -22,6 +22,12 @@ orgs.newOrg('eclipse-set') {
     orgs.newOrgSecret('GITLAB_API_TOKEN') {
       value: "pass:bots/technology.set/gitlab.eclipse.org/api-token",
     },
+    orgs.newOrgSecret('GITHUB_BOT_USERNAME') {
+      value: "pass:bots/technology.set/github.com/username",
+    },
+    orgs.newOrgSecret('GITHUB_BOT_TOKEN') {
+      value: "pass:bots/technology.set/github.com/api-token",
+    },
   ],
   _repositories+:: [
     orgs.newRepo('browser') {
@@ -65,11 +71,6 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         custom_branch_protection_rule('main'),
-      ],
-      secrets+: [
-        orgs.newRepoSecret('ACTIONS_RUNTIME_TOKEN') {
-          value: "********",
-        },
       ],
     },
     orgs.newRepo('toolboxmodel') {


### PR DESCRIPTION
This adds the access token for https://github.com/eclipse-set-bot as org secrets in order to allow actions to bypass the branch protection. According to the discussion in https://github.com/eclipse-set/.eclipsefdn/pull/3 github-set-bot should be able to push regardless of branch protection. 

To do this we need to authenticate as the bot user rather than via the default GITHUB_TOKEN-token, which does not own the repository. Again, pass-paths are just a guess from information gathered from eclipse-cbi. 

--- 

This also removes the odd `ACTIONS_RUNTIME_TOKEN` which was noticed/added in #4. It seems to be unused and is likely an artifact of some Docker related action being used. In any case it shouldn't actually exist.

