### PR TITLE
Enable branch protection for release branches

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -33,6 +33,7 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         custom_branch_protection_rule('main'),
+        custom_branch_protection_rule('release/*'),
       ],
     },
     orgs.newRepo('build') {
@@ -55,6 +56,7 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         custom_branch_protection_rule('main'),
+        custom_branch_protection_rule('release/*'),
       ],
     },
     orgs.newRepo('set') {
@@ -65,6 +67,7 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         custom_branch_protection_rule('main'),
+        custom_branch_protection_rule('release/*'),
       ],
       secrets+: [
         orgs.newRepoSecret('ACTIONS_RUNTIME_TOKEN') {
@@ -81,6 +84,7 @@ orgs.newOrg('eclipse-set') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         custom_branch_protection_rule('main'),
+        custom_branch_protection_rule('release/*'),
       ],      
     },
   ],


### PR DESCRIPTION
This adds branch protection for our release branches for all repositories, excluding `build` (which does not have releases). 