### PR TITLE
Set packages containers to public

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -12,7 +12,6 @@ orgs.newOrg('eclipse-set') {
     description: "",
     name: "Eclipse SET",
     packages_containers_internal: false,
-    packages_containers_public: true,
     readers_can_create_discussions: true,
     web_commit_signoff_required: false,
   },

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -12,7 +12,7 @@ orgs.newOrg('eclipse-set') {
     description: "",
     name: "Eclipse SET",
     packages_containers_internal: false,
-    packages_containers_public: false,
+    packages_containers_public: true,
     readers_can_create_discussions: true,
     web_commit_signoff_required: false,
   },


### PR DESCRIPTION
- This set container packages in eclipse-set to public
- We have push "rust-docker" to gcrp.io/eclipse-set , but while build job can't this container pull. And i think the resaon is, the container is private. https://github.com/orgs/eclipse-set/packages?repo_name=build