### PR TITLE
Remove restricts_pushes on release branch

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -7,9 +7,8 @@ local custom_branch_protection_rule(pattern) =
 
 local release_branch_protection_rule() = 
   orgs.newBranchProtectionRule('release/*') {
-    restricts_pushes: true,
     blocks_creations: true,
-    push_restrictions: ['@eclipse-set-bot'],
+    push_restrictions: ['eclipse-set-bot'],
     required_approving_review_count: 0,
   };
 

--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -7,8 +7,6 @@ local custom_branch_protection_rule(pattern) =
 
 local release_branch_protection_rule() = 
   orgs.newBranchProtectionRule('release/*') {
-    blocks_creations: true,
-    push_restrictions: ['eclipse-set-bot'],
     required_approving_review_count: 0,
   };
 


### PR DESCRIPTION
- I don't know why, the `push_restrictions` not work. The `eclipse-set-bot` haven't permission to create/push new release branch.
See: https://github.com/eclipse-set/model/actions/runs/18131335573